### PR TITLE
Fix: Fix favor update condition

### DIFF
--- a/src/main/java/com/eopueopu/frenda/handler/MonsterHandler.java
+++ b/src/main/java/com/eopueopu/frenda/handler/MonsterHandler.java
@@ -41,7 +41,7 @@ public class MonsterHandler {
 	
 	public void isFavorIncreased(String user_id) throws Exception {
 		
-		if(!monsterDAO.getFavorIncreasedValue(user_id))
+		if(monsterDAO.getFavorIncreasedValue(user_id))
 			throw new InvalidIncreaseFavorConditionException();
 	}
 	


### PR DESCRIPTION
마지막 몬스터 사냥 로그의 호감도 증가 여부 체크 수정
(이전에는 호감도를 올리지 않은 경우에 Exception 발생)

Resolves #30